### PR TITLE
Use the largest index as size

### DIFF
--- a/src/main/kotlin/com/displee/cache/CacheLibrary.kt
+++ b/src/main/kotlin/com/displee/cache/CacheLibrary.kt
@@ -123,7 +123,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
     fun createIndex(compressionType: CompressionType = CompressionType.GZIP, version: Int = 6, revision: Int = 0,
                     named: Boolean = false, whirlpool: Boolean = false, flag4: Boolean = false, flag8: Boolean = false,
                     writeReferenceTable: Boolean = true): Index {
-        val id = indices.size
+        val id = indexCount()
         val raf = RandomAccessFile(File(path, "$CACHE_FILE_NAME.idx$id"), "rw")
         val index = (if (is317()) Index317(this, id, raf) else Index(this, id, raf)).also { indices[id] = it }
         if (!writeReferenceTable) {
@@ -254,7 +254,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         if (is317()) {
             throw UnsupportedOperationException("317 not supported to remove indices yet.")
         }
-        val id = indices.size - 1
+        val id = indexCount() - 1
         val index = indices[id] ?: return
         index.close()
         val file = File(path, "$CACHE_FILE_NAME.idx$id")
@@ -267,9 +267,9 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
 
     @JvmOverloads
     fun generateUkeys(writeWhirlpool: Boolean = true, exponent: BigInteger? = null, modulus: BigInteger? = null): ByteArray {
-        val buffer = OutputBuffer(6 + indices.size * 72)
+        val buffer = OutputBuffer(6 + indexCount() * 72)
         if (writeWhirlpool) {
-            buffer.writeByte(indices.size)
+            buffer.writeByte(indexCount())
         }
         val emptyWhirlpool = ByteArray(WHIRLPOOL_SIZE)
         for (index in indices()) {
@@ -360,8 +360,10 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
 
     fun isOSRS(): Boolean {
         val index = index(2)
-        return index.revision >= 300 && indices.size <= 23
+        return index.revision >= 300 && indexCount() <= 23
     }
+
+    private fun indexCount() = indices.maxBy { it.key }?.key ?: 0
 
     fun isRS3(): Boolean {
         return rs3


### PR DESCRIPTION
Fixes issue where incorrect index count is used in `generatedUkeys` when number of index files doesn't add up to the index count