### PR TITLE
Remove flagging from the archive set xtea method and only hardcode the compression type for valid xteas

### DIFF
--- a/src/main/kotlin/com/displee/cache/index/archive/Archive.kt
+++ b/src/main/kotlin/com/displee/cache/index/archive/Archive.kt
@@ -29,11 +29,11 @@ open class Archive(val id: Int, var hashName: Int = 0, xtea: IntArray? = null) :
         get() = _xtea
         set(value) {
             _xtea = value
-            if (read) {
+            if (read && _xtea != null) {
                 //bzip2 compression fails when xteas are set for some reason, cheap fix
                 compressionType = CompressionType.GZIP
                 compressor = GZIPCompressor()
-                flag()
+                //flag()
             }
         }
 
@@ -173,6 +173,7 @@ open class Archive(val id: Int, var hashName: Int = 0, xtea: IntArray? = null) :
                 flag = true
             }
             if (flag) {
+                println("Flagged")
                 flag()
             }
         }

--- a/src/main/kotlin/com/displee/cache/index/archive/Archive.kt
+++ b/src/main/kotlin/com/displee/cache/index/archive/Archive.kt
@@ -173,7 +173,6 @@ open class Archive(val id: Int, var hashName: Int = 0, xtea: IntArray? = null) :
                 flag = true
             }
             if (flag) {
-                println("Flagged")
                 flag()
             }
         }

--- a/src/main/kotlin/com/displee/cache/index/archive/Archive.kt
+++ b/src/main/kotlin/com/displee/cache/index/archive/Archive.kt
@@ -28,13 +28,14 @@ open class Archive(val id: Int, var hashName: Int = 0, xtea: IntArray? = null) :
     var xtea: IntArray?
         get() = _xtea
         set(value) {
-            _xtea = value
-            if (read && _xtea != null) {
+            // only flag the archive for update when it was read and the xtea got changed
+            if (read && !(_xtea contentEquals value)) {
                 //bzip2 compression fails when xteas are set for some reason, cheap fix
                 compressionType = CompressionType.GZIP
                 compressor = GZIPCompressor()
-                //flag()
+                flag()
             }
+            _xtea = value
         }
 
     var read = false


### PR DESCRIPTION
Only hardcode the compression type to gzip if the xtea is actually valid, also don't flag the archive, as there shouldn't be any need to do that and it slows down the performance drastically in some cases

Example: reading all the model archives and then just updating the cache takes a while because every single archive is flagged from the xtea set method, it should only be flagged if the archive has actually been modified (altho one could argue that setting the compression type is a modification)
I haven't found any issues after removing the flagging in the set xtea method however, but even if that must be kept for some reason then the null check should exist at the very least so that it only does it for valid xteas.