### PR TITLE
fix: reference table encoding for osrs 229+

### DIFF
--- a/src/main/kotlin/com/displee/cache/index/ReferenceTable.kt
+++ b/src/main/kotlin/com/displee/cache/index/ReferenceTable.kt
@@ -137,24 +137,16 @@ open class ReferenceTable(protected val origin: CacheLibrary, val id: Int) : Com
         if (isNamed()) {
             archives.forEach { buffer.writeInt(it.hashName) }
         }
-        if (origin.isRS3()) {
-            archives.forEach { buffer.writeInt(it.crc) }
-            if (hasChecksums()) {
-                archives.forEach { buffer.writeInt(it.checksum) }
-            }
-            if (hasWhirlpool()) {
-                val empty = ByteArray(WHIRLPOOL_SIZE)
-                archives.forEach { buffer.writeBytes(it.whirlpool ?: empty) }
-            }
-            if (hasLengths()) {
-                archives.forEach { buffer.writeInt(it.length).writeInt(it.uncompressedLength) }
-            }
-        } else {
-            if (hasWhirlpool()) {
-                val empty = ByteArray(WHIRLPOOL_SIZE)
-                archives.forEach { buffer.writeBytes(it.whirlpool ?: empty) }
-            }
-            archives.forEach { buffer.writeInt(it.crc) }
+        archives.forEach { buffer.writeInt(it.crc) }
+        if (hasChecksums()) {
+            archives.forEach { buffer.writeInt(it.checksum) }
+        }
+        if (hasWhirlpool()) {
+            val empty = ByteArray(WHIRLPOOL_SIZE)
+            archives.forEach { buffer.writeBytes(it.whirlpool ?: empty) }
+        }
+        if (hasLengths()) {
+            archives.forEach { buffer.writeInt(it.length).writeInt(it.uncompressedLength) }
         }
         archives.forEach { buffer.writeInt(it.revision) }
         archives.forEach { writeFun(it.files.size) }


### PR DESCRIPTION
PR https://github.com/Displee/rs-cache-library/pull/71 removed rs3 related checks for reading the reference table for rs3. This PR also removes those checks from writing to ensure that the reference table does not get corrupted by not writing all the data required by the mask 